### PR TITLE
Bug 2062579: IBMCloud: Verify machine profile

### DIFF
--- a/pkg/actuators/client/mock/client_mock_generated.go
+++ b/pkg/actuators/client/mock/client_mock_generated.go
@@ -228,3 +228,18 @@ func (mr *MockClientMockRecorder) InstanceGetProfile(profileName interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceGetProfile", reflect.TypeOf((*MockClient)(nil).InstanceGetProfile), profileName)
 }
+
+// VerifyInstanceProfile mocks base method.
+func (m *MockClient) VerifyInstanceProfile(profile string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyInstanceProfile", profile)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyInstanceProfile indicates an expected call of VerifyInstanceProfile.
+func (mr *MockClientMockRecorder) VerifyInstanceProfile(profile interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyInstanceProfile", reflect.TypeOf((*MockClient)(nil).VerifyInstanceProfile), profile)
+}


### PR DESCRIPTION
Verify the machine's instance profile during creation to prevent
the machine from being requeued to Provisioning when an invalid
instance profile is provided.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2062579