### PR TITLE
Fix version

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -32,5 +32,5 @@ var (
 	Version = semver.MustParse(strings.TrimLeft(Raw, "v"))
 
 	// String is the human-friendly representation of the version.
-	String = fmt.Sprintf("ClusterAPIProviderIBMCloud %s", Raw)
+	String = fmt.Sprintf("MachineAPIProviderIBMCloud %s", Raw)
 )


### PR DESCRIPTION
Currently the component is called `ClusterAPIProviderIBMCloud`, which is not correct. It should be `MachineAPIProviderIBMCloud`.