### PR TITLE
Add secondary interfaces support 

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -180,9 +180,16 @@ func (r *Reconciler) reconcileMachineWithCloudState(conditionFailed *ibmcloudpro
 
 	// Update Machine Status Addresses
 	ipAddr := *newInstance.PrimaryNetworkInterface.PrimaryIpv4Address
+	networkInterfaces := newInstance.NetworkInterfaces
 	if ipAddr != "" {
 		networkAddresses := []apicorev1.NodeAddress{{Type: apicorev1.NodeInternalDNS, Address: r.machine.Name}}
 		networkAddresses = append(networkAddresses, apicorev1.NodeAddress{Type: apicorev1.NodeInternalIP, Address: ipAddr})
+		for _, secondaryInterface := range networkInterfaces {
+			ipAddr = *secondaryInterface.PrimaryIpv4Address
+			if ipAddr != "" {
+				networkAddresses = append(networkAddresses, apicorev1.NodeAddress{Type: apicorev1.NodeInternalIP, Address: ipAddr})
+			}
+		}
 		r.machine.Status.Addresses = networkAddresses
 	} else {
 		return fmt.Errorf("could not get the primary ipv4 address of instance: %v", newInstance.Name)

--- a/pkg/apis/ibmcloudprovider/v1/ibmcloudproviderconfig_types.go
+++ b/pkg/apis/ibmcloudprovider/v1/ibmcloudproviderconfig_types.go
@@ -67,6 +67,9 @@ type IBMCloudMachineProviderSpec struct {
 	// PrimaryNetworkInterface is required to specify subnet
 	PrimaryNetworkInterface NetworkInterface `json:"primaryNetworkInterface"`
 
+	// Collection of additional network interfaces to create for the virtual server instance.
+	NetworkInterfaces []NetworkInterface `json:"networkInterfaces,omitempty"`
+
 	// SSHKeys is the SSH pub keys that will be used to access virtual service instance
 	// SSHKeys []*string `json:"sshKeys,omitempty"`
 
@@ -79,8 +82,13 @@ type IBMCloudMachineProviderSpec struct {
 
 // NetworkInterface struct
 type NetworkInterface struct {
+	// Indicates whether source IP spoofing is allowed on this interface. If false, source IP spoofing is prevented on this
+	// interface. If true, source IP spoofing is allowed on this interface.
+	AllowIPSpoofing bool `json:"allowIPSpoofing,omitempty"`
+
 	// Subnet name of the network interface
 	Subnet string `json:"subnet"`
+
 	// SecurityGroups holds a list of security group names
 	SecurityGroups []string `json:"securityGroups"`
 }


### PR DESCRIPTION
This PR is to solve the issue https://github.com/openshift/machine-api-provider-ibmcloud/issues/8.

With the below providerSpec in MachineSet, it will allow auto-scaling an instance with multiple secondary interface attachments specifying security group and IP-spoofing attributes. 

<img src="https://user-images.githubusercontent.com/11749848/196316602-2281f126-f1e5-43c3-a324-47cff14757c6.png" width="500">

**What are added in this PR**
- `NetworkInterfaces` attribute in **IBMCloudMachineProviderSpec**
- `AllowIPSpoofing` attribute in **NetworkInterface**
- Setting `NetworkInterfaces` attribute in **vpcv1.InstancePrototype** at **InstanceCreate**
- Updating `Addresses` attribute of secondary interfaces in **machine.Status** at **reconcileMachineWithCloudState**
 
Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>