### PR TITLE
CORS-2387: IBMCloud: Add NetworkResourceGroup

### DIFF
--- a/pkg/actuators/client/client.go
+++ b/pkg/actuators/client/client.go
@@ -262,6 +262,18 @@ func (c *ibmCloudClient) InstanceCreate(machineName string, machineProviderConfi
 		return nil, err
 	}
 
+	// If NetworkResourceGroup exists, get the Network Resource Group ID
+	// Otherwise, default to Resource Group ID
+	var networkResourceGroupID string
+	if machineProviderConfig.NetworkResourceGroup != "" {
+		networkResourceGroupID, err = c.GetResourceGroupIDByName(machineProviderConfig.NetworkResourceGroup)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		networkResourceGroupID = resourceGroupID
+	}
+
 	// Get Custom Image ID
 	imageID, err := c.GetCustomImageByName(machineProviderConfig.Image, resourceGroupID)
 	if err != nil {
@@ -276,14 +288,14 @@ func (c *ibmCloudClient) InstanceCreate(machineName string, machineProviderConfi
 
 	// Get VPC ID
 	vpcName := machineProviderConfig.VPC
-	vpcID, err := c.GetVPCIDByName(vpcName, resourceGroupID)
+	vpcID, err := c.GetVPCIDByName(vpcName, networkResourceGroupID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get Subnet ID
 	subnetName := machineProviderConfig.PrimaryNetworkInterface.Subnet
-	subnetID, err := c.GetSubnetIDbyName(subnetName, resourceGroupID)
+	subnetID, err := c.GetSubnetIDbyName(subnetName, networkResourceGroupID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/ibmcloudprovider/v1/ibmcloudproviderconfig_types.go
+++ b/pkg/apis/ibmcloudprovider/v1/ibmcloudproviderconfig_types.go
@@ -61,8 +61,17 @@ type IBMCloudMachineProviderSpec struct {
 	// Zone where the virtual server instance will be created
 	Zone string `json:"zone"`
 
-	// ResourceGroup of VPC
+	// ResourceGroup of the machines. This may be the same as NetworkResourceGroup if the machines are
+	// created in the same Resource Group as the network resources.
 	ResourceGroup string `json:"resourceGroup"`
+
+	// NetworkResourceGroup is the Resource Group for network resources like the VPC and Subnets used by the cluster,
+	// where ResourceGroupName will contain the remaining resources (e.g., machines). This may be the same as
+	// ResourceGroup, if the machines are created in the same Resource Group as the network resources.
+	// If empty, the NetworkResourceGroup is considered to be the same value as ResourceGroup, which will contain
+	// the network and remaining resources of the cluster.
+	// (optional)
+	NetworkResourceGroup string `json:"networkResourceGroup,omitempty"`
 
 	// PrimaryNetworkInterface is required to specify subnet
 	PrimaryNetworkInterface NetworkInterface `json:"primaryNetworkInterface"`


### PR DESCRIPTION
Add support for a NetworkResourceGroup in the MachineProviderSpec, and the logic for performing lookups during a machine creation for IBM Cloud.

Related: https://issues.redhat.com/browse/CORS-2387