### PR TITLE
OCPCLOUD-2227: IBMCloud: Fix version for binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-provider-ibmcloud
+
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
  && GOPROXY=off NO_DOCKER=1 make build
+RUN mkdir -p /tmp/build && cp _output/linux/$(go env GOARCH)/machine-controller-manager /tmp/build/machine-controller-manager
 
 FROM registry.ci.openshift.org/ocp/4.15:base
-COPY --from=builder /go/src/github.com/openshift/machine-api-provider-ibmcloud/bin/machine-controller-manager /
+COPY --from=builder /tmp/build/machine-controller-manager /

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,7 @@ unit: # Run unit test
 
 .PHONY: build
 build: ## build binaries
-	$(DOCKER_CMD) go build $(GOGCFLAGS) -o "bin/machine-controller-manager" \
-               -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/manager"
+	./hack/build-go.sh
 
 .PHONY: images
 images: ## Create images

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -eu
+
+REPO=github.com/openshift/machine-api-provider-ibmcloud
+GOFLAGS=${GOFLAGS:--mod=vendor}
+GLDFLAGS=${GLDFLAGS:-}
+
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+
+GOOS=${GOOS:-${GOHOSTOS}}
+GOARCH=${GOARCH:-${GOHOSTARCH}}
+
+# Go to the root of the repo
+cd "$(git rev-parse --show-cdup)"
+
+VERSION_OVERRIDE=${VERSION_OVERRIDE:-${OS_GIT_VERSION:-}}
+if [ -z "${VERSION_OVERRIDE:-}" ]; then
+	echo "Using version from git..."
+	VERSION_OVERRIDE="v0.0.0-$(git log -n1 --format=%h)"
+fi
+
+GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
+
+eval $(go env)
+
+if [ -z ${BIN_PATH+a} ]; then
+	export BIN_PATH=_output/${GOOS}/${GOARCH}
+fi
+
+mkdir -p ${BIN_PATH}
+
+echo "Building ${REPO} (${VERSION_OVERRIDE})"
+GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/machine-controller-manager ${REPO}/cmd/...


### PR DESCRIPTION
Fix the release version for the go binary to resolve build and run issues with missing/incompatible versions.

Related: https://issues.redhat.com/browse/OCPCLOUD-2227