### PR TITLE
OCPBUGS-28965: update textlogger usage

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -90,9 +90,20 @@ func main() {
 		"Address for hosting metrics",
 	)
 
-	klog.InitFlags(nil)
-	flag.Set("logtostderr", "true")
+	logToStderr := flag.Bool(
+		"logtostderr",
+		true,
+		"Log to Stderr instead of files",
+	)
+
+	textLoggerConfig := textlogger.NewConfig()
+	textLoggerConfig.AddFlags(flag.CommandLine)
+	ctrl.SetLogger(textlogger.NewLogger(textLoggerConfig))
+
 	flag.Parse()
+	if logToStderr != nil {
+		klog.LogToStderr(*logToStderr)
+	}
 
 	if *printVersion {
 		fmt.Println(version.String)
@@ -150,7 +161,6 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	ctrl.SetLogger(textlogger.NewLogger(nil))
 	setupLog := ctrl.Log.WithName("setup")
 	if err = (&machinesetcontroller.Reconciler{
 		Client: mgr.GetClient(),


### PR DESCRIPTION
This change adds the configuration and command line flags setup for the textlogger configuration. It is being added to address an error when botting with the current code, that was changed to an updated klogr during the kubernetes 1.29 update. The configuration code is inspired by the machine-api-provider-vsphere main function.