### PR TITLE
OCPBUGS-27872: add an extra vendor exclude to snyk config

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - "vendor/**"
+    - "**/vendor/**"


### PR DESCRIPTION
it seemed like the scan was failing on the vendor folder during the cachito expansion, this change adds an extra vendor option to the global excludes.