### PR TITLE
OCPBUGS-77445: [release-4.21] bump vpc go sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/IBM/go-sdk-core/v5 v5.18.5
 	github.com/IBM/platform-services-go-sdk v0.74.0
-	github.com/IBM/vpc-go-sdk v0.64.0
+	github.com/IBM/vpc-go-sdk v0.64.2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/ignition/v2 v2.20.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/IBM/go-sdk-core/v5 v5.18.5 h1:g0JRl3sYXJczB/yuDlrN6x22LJ6jIxhp0Sa4ARN
 github.com/IBM/go-sdk-core/v5 v5.18.5/go.mod h1:KonTFRR+8ZSgw5cxBSYo6E4WZoY1+7n1kfHM82VcjFU=
 github.com/IBM/platform-services-go-sdk v0.74.0 h1:rtadzqB+EjK5M4pMW2JCEgJqV/1qEVKjBCn7aJsj4SQ=
 github.com/IBM/platform-services-go-sdk v0.74.0/go.mod h1:LSaXGGJUGGPMCCtG1/24r9LJEbF0hmpXtQOhABRk0PY=
-github.com/IBM/vpc-go-sdk v0.64.0 h1:0x2jakapXxXYTTr0EdrwuXa6h0couSK+FTDGxd8jChA=
-github.com/IBM/vpc-go-sdk v0.64.0/go.mod h1:VBR6bAznHsNCFA89Ue4JFQpqCcFp8F5neqbCFCyks4Q=
+github.com/IBM/vpc-go-sdk v0.64.2 h1:iqcUcYyu7RpwP5LCYlvOnYYtLiLfn4nNAAkAnEiKJKQ=
+github.com/IBM/vpc-go-sdk v0.64.2/go.mod h1:6rEWo6HGt7S0Nbw7WdJQiVcz9Z+mRDmyycK4xc4kWlw=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=

--- a/vendor/github.com/IBM/vpc-go-sdk/common/version.go
+++ b/vendor/github.com/IBM/vpc-go-sdk/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.64.0"
+const Version = "0.64.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/IBM/go-sdk-core/v5/core
 ## explicit; go 1.21
 github.com/IBM/platform-services-go-sdk/common
 github.com/IBM/platform-services-go-sdk/resourcemanagerv2
-# github.com/IBM/vpc-go-sdk v0.64.0
+# github.com/IBM/vpc-go-sdk v0.64.2
 ## explicit; go 1.21
 github.com/IBM/vpc-go-sdk/common
 github.com/IBM/vpc-go-sdk/vpcv1


### PR DESCRIPTION
The newer versions of the VPC API introduced breaking changes to security
group rule protocols.
The SDK was patched to handle additional protocol values introduced in
newer API versions, ensuring older SDK releases do not fail when reading
security group or network ACL rules created with expanded protocol support.