### PR TITLE
[release-4.18] OCPBUGS-81647: bump vpc go sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/IBM/go-sdk-core/v5 v5.17.5
 	github.com/IBM/platform-services-go-sdk v0.69.1
-	github.com/IBM/vpc-go-sdk v0.58.0
+	github.com/IBM/vpc-go-sdk v0.58.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/ignition/v2 v2.19.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/IBM/go-sdk-core/v5 v5.17.5 h1:AjGC7xNee5tgDIjndekBDW5AbypdERHSgib3EZ1
 github.com/IBM/go-sdk-core/v5 v5.17.5/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
 github.com/IBM/platform-services-go-sdk v0.69.1 h1:Wb8BYVpsPIppWbOQCgF7ytm+BbSOXdWWCf9zcZ6xGA4=
 github.com/IBM/platform-services-go-sdk v0.69.1/go.mod h1:ZP3zUDxR1qRdUqzFdnJOlQN0QpVYol2eOUCv4uk03Jc=
-github.com/IBM/vpc-go-sdk v0.58.0 h1:Slk1jkcV7tPnf0iECQV2Oja7W8Bom0z7k9M4fMBY4bI=
-github.com/IBM/vpc-go-sdk v0.58.0/go.mod h1:swmxiYLT+OfBsBYqJWGeRd6NPmBk4u/het2PZdtzIaw=
+github.com/IBM/vpc-go-sdk v0.58.1 h1:MTelXHgb03iaTrbIDSurb+I6i1v3FdvUPrhnZ15GO7E=
+github.com/IBM/vpc-go-sdk v0.58.1/go.mod h1:swmxiYLT+OfBsBYqJWGeRd6NPmBk4u/het2PZdtzIaw=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/vendor/github.com/IBM/vpc-go-sdk/common/version.go
+++ b/vendor/github.com/IBM/vpc-go-sdk/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.58.0"
+const Version = "0.58.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/IBM/go-sdk-core/v5/core
 ## explicit; go 1.21
 github.com/IBM/platform-services-go-sdk/common
 github.com/IBM/platform-services-go-sdk/resourcemanagerv2
-# github.com/IBM/vpc-go-sdk v0.58.0
+# github.com/IBM/vpc-go-sdk v0.58.1
 ## explicit; go 1.20
 github.com/IBM/vpc-go-sdk/common
 github.com/IBM/vpc-go-sdk/vpcv1


### PR DESCRIPTION
The newer versions of the VPC API introduced breaking changes to security
group rule protocols.
The SDK was patched to handle additional protocol values introduced in
newer API versions, ensuring older SDK releases do not fail when reading
security group or network ACL rules created with expanded protocol support.