### PR TITLE
[release-4.17] OCPBUGS-81667: bump vpc go sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/IBM/go-sdk-core/v5 v5.14.1
 	github.com/IBM/platform-services-go-sdk v0.52.1
-	github.com/IBM/vpc-go-sdk v0.42.0
+	github.com/IBM/vpc-go-sdk v0.42.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/ignition/v2 v2.14.0
 	github.com/go-logr/logr v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/IBM/go-sdk-core/v5 v5.14.1 h1:WR1r0zz+gDW++xzZjF41r9ueY4JyjS2vgZjiYs8
 github.com/IBM/go-sdk-core/v5 v5.14.1/go.mod h1:MUvIr/1mgGh198ZXL+ByKz9Qs1JoEh80v/96x8jPXNY=
 github.com/IBM/platform-services-go-sdk v0.52.1 h1:fUCtYMAekzsWO/ylZi31j6BpyJ1xKb39NG62zBXePbg=
 github.com/IBM/platform-services-go-sdk v0.52.1/go.mod h1:6LxcUhIaSLP4SuQJXF9oLXBamSQogs5D9BcVwr4hmfU=
-github.com/IBM/vpc-go-sdk v0.42.0 h1:fbBeRPoiL7ut1RnZFxRq2eExKxAT7iAyQvaVk9Frni0=
-github.com/IBM/vpc-go-sdk v0.42.0/go.mod h1:kRz9tqPvpHoA/qGrC/qVjTbi4ICuTChpG76L89liGL4=
+github.com/IBM/vpc-go-sdk v0.42.1 h1:btHFTQ0aieO4+Jcy5fugmTUHKVH04hpmXD09o/CUsM0=
+github.com/IBM/vpc-go-sdk v0.42.1/go.mod h1:kRz9tqPvpHoA/qGrC/qVjTbi4ICuTChpG76L89liGL4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/vendor/github.com/IBM/vpc-go-sdk/common/version.go
+++ b/vendor/github.com/IBM/vpc-go-sdk/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.42.0"
+const Version = "0.42.1"

--- a/vendor/github.com/IBM/vpc-go-sdk/vpcv1/vpc_v1.go
+++ b/vendor/github.com/IBM/vpc-go-sdk/vpcv1/vpc_v1.go
@@ -56715,7 +56715,8 @@ func UnmarshalNetworkACLRule(m map[string]json.RawMessage, result interface{}) (
 	} else if discValue == "udp" {
 		err = core.UnmarshalModel(m, "", result, UnmarshalNetworkACLRuleNetworkACLRuleProtocolTcpudp)
 	} else {
-		err = fmt.Errorf("unrecognized value for discriminator property 'protocol': %s", discValue)
+		// Fallback to base NetworkACLRule for unknown protocols
+		err = core.UnmarshalModel(m, "", result, UnmarshalNetworkACLRuleGeneric)
 	}
 	return
 }
@@ -57008,8 +57009,129 @@ func UnmarshalNetworkACLRuleItem(m map[string]json.RawMessage, result interface{
 	} else if discValue == "udp" {
 		err = core.UnmarshalModel(m, "", result, UnmarshalNetworkACLRuleItemNetworkACLRuleProtocolTcpudp)
 	} else {
-		err = fmt.Errorf("unrecognized value for discriminator property 'protocol': %s", discValue)
+		// Fallback to base NetworkACLRuleItem for unknown protocols
+		err = core.UnmarshalModel(m, "", result, UnmarshalNetworkACLRuleItemGeneric)
 	}
+	return
+}
+
+// UnmarshalNetworkACLRuleItemGeneric unmarshals the base NetworkACLRuleItem fields for unknown protocol types
+func UnmarshalNetworkACLRuleItemGeneric(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(NetworkACLRuleItem)
+	err = core.UnmarshalPrimitive(m, "action", &obj.Action)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "before", &obj.Before, UnmarshalNetworkACLRuleReference)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "destination", &obj.Destination)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "direction", &obj.Direction)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "ip_version", &obj.IPVersion)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "protocol", &obj.Protocol)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "source", &obj.Source)
+	if err != nil {
+		return
+	}
+
+	// Attempt to unmarshal optional protocol-specific fields - ignore errors as these may not be present
+	_ = core.UnmarshalPrimitive(m, "code", &obj.Code)
+	_ = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	_ = core.UnmarshalPrimitive(m, "destination_port_max", &obj.DestinationPortMax)
+	_ = core.UnmarshalPrimitive(m, "destination_port_min", &obj.DestinationPortMin)
+	_ = core.UnmarshalPrimitive(m, "source_port_max", &obj.SourcePortMax)
+	_ = core.UnmarshalPrimitive(m, "source_port_min", &obj.SourcePortMin)
+
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// UnmarshalNetworkACLRuleGeneric unmarshals the base NetworkACLRuleItem fields for unknown protocol types
+func UnmarshalNetworkACLRuleGeneric(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(NetworkACLRule)
+	err = core.UnmarshalPrimitive(m, "action", &obj.Action)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "before", &obj.Before, UnmarshalNetworkACLRuleReference)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "destination", &obj.Destination)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "direction", &obj.Direction)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "ip_version", &obj.IPVersion)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "protocol", &obj.Protocol)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "source", &obj.Source)
+	if err != nil {
+		return
+	}
+
+	// Attempt to unmarshal optional protocol-specific fields - ignore errors as these may not be present
+	_ = core.UnmarshalPrimitive(m, "code", &obj.Code)
+	_ = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	_ = core.UnmarshalPrimitive(m, "destination_port_max", &obj.DestinationPortMax)
+	_ = core.UnmarshalPrimitive(m, "destination_port_min", &obj.DestinationPortMin)
+	_ = core.UnmarshalPrimitive(m, "source_port_max", &obj.SourcePortMax)
+	_ = core.UnmarshalPrimitive(m, "source_port_min", &obj.SourcePortMin)
+
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
 
@@ -61965,8 +62087,47 @@ func UnmarshalSecurityGroupRule(m map[string]json.RawMessage, result interface{}
 	} else if discValue == "udp" {
 		err = core.UnmarshalModel(m, "", result, UnmarshalSecurityGroupRuleSecurityGroupRuleProtocolTcpudp)
 	} else {
-		err = fmt.Errorf("unrecognized value for discriminator property 'protocol': %s", discValue)
+		// Fallback to base SecurityGroupRule for unknown protocols
+		err = core.UnmarshalModel(m, "", result, UnmarshalSecurityGroupRuleGeneric)
 	}
+	return
+}
+
+// UnmarshalSecurityGroupRuleGeneric unmarshals the base SecurityGroupRule fields for unknown protocol types
+func UnmarshalSecurityGroupRuleGeneric(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(SecurityGroupRule)
+	err = core.UnmarshalPrimitive(m, "direction", &obj.Direction)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "ip_version", &obj.IPVersion)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "remote", &obj.Remote, UnmarshalSecurityGroupRuleRemote)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "protocol", &obj.Protocol)
+	if err != nil {
+		return
+	}
+
+	// Attempt to unmarshal optional fields - ignore errors as these may not be present
+	_ = core.UnmarshalPrimitive(m, "code", &obj.Code)
+	_ = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	_ = core.UnmarshalPrimitive(m, "port_max", &obj.PortMax)
+	_ = core.UnmarshalPrimitive(m, "port_min", &obj.PortMin)
+
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/IBM/go-sdk-core/v5/core
 ## explicit; go 1.19
 github.com/IBM/platform-services-go-sdk/common
 github.com/IBM/platform-services-go-sdk/resourcemanagerv2
-# github.com/IBM/vpc-go-sdk v0.42.0
+# github.com/IBM/vpc-go-sdk v0.42.1
 ## explicit; go 1.18
 github.com/IBM/vpc-go-sdk/common
 github.com/IBM/vpc-go-sdk/vpcv1


### PR DESCRIPTION
The newer versions of the VPC API introduced breaking changes to security
group rule protocols.
The SDK was patched to handle additional protocol values introduced in
newer API versions, ensuring older SDK releases do not fail when reading
security group or network ACL rules created with expanded protocol support.